### PR TITLE
Add ChefSpec matchers

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,15 @@
+if defined?(ChefSpec)
+
+  def replace_bsw_gpg_load_key_from_string(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:bsw_gpg_load_key_from_string, :replace, resource)
+  end
+
+  def replace_bsw_gpg_load_key_from_chef_vault(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:bsw_gpg_load_key_from_chef_vault, :replace, resource)
+  end
+
+  def replace_bsw_gpg_load_key_from_key_server(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:bsw_gpg_load_key_from_key_server, :replace, resource)
+  end
+
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,3 +7,6 @@ description 'Installs/Configures gpg using an LWRP based approach'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.2.2'
 supports 'ubuntu', '14.04'
+supports 'redhat'
+supports 'centos'
+supports 'scientific'


### PR DESCRIPTION
This adds matchers to enable ChefSpec testing.

Also updated metadata to indicate that this should work with Red Hat based distros. This has been tested on CentOS 6.5 and 7.
